### PR TITLE
Feature #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 dist
 build
 test/outputs
+*.html

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,17 @@
             "program": "${file}",
             "console": "integratedTerminal",
             "justMyCode": false
+        },
+        {
+            "name": "Parse with tree view",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "confuk.main",
+            "args": [
+                "parse", "test/test_interpolation.toml", "-t"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -279,3 +279,45 @@ dump_config(cfg, "some_cfg.json")
 
 > [!warning]
 > Not all types in your config object might be serializable, especially if you're using custom classes. When loading a config using `omegaconf` adapter, we're ensuring that the output is serialized properly, with other config backends it might not be so pretty at the moment. If you're running into trouble my suggestion is to dump to a Pickle and use something like [objexplore](https://github.com/kylepollina/objexplore) to load the Pickle back again and explore the contents of the constructed config.
+
+### Config file documentation
+
+When designing a config file, you will often want to also document what each property means. Sadly enough, there aren't that many packages which handle config documentation very well. This is partially due to limitations of file formats used for configuration. For example YAML and TOML specifications do not cover parsing comments, meanwhile a lot of folks out there use comments to document parts of their config files:
+
+```yaml
+apple:
+  # Color of the apple
+  color: red
+  # Size of the apple
+  size: medium
+```
+
+We thought of implementing parsing for these but seriously, who would have time to build a reliable new parser for YAML or TOML which also processes comments correctly? Instead, it was much simpler to go with a separate documentation file. For the example above, you would create another file, e.g. `config.doc.yaml`:
+
+```yaml
+apple:
+  _doc_: properties of an apple
+  color:
+    _doc_: Color of the apple
+  size:
+    _doc_: Size of the apple
+```
+
+Then you can simply run:
+
+```bash
+confuk doc ./config.doc.yaml
+```
+
+This will display the documentation in the console, paged for your pleasure of reading. You have currently the following alternative options to display the contents of the documentation:
+
+- `confuk doc ./config.doc.yaml -f test.html` – as an HTML file (append `-o` to open it in the web browser right away)
+- `confuk doc ./config.doc.yaml -t` – in a tree view (might be more helpful for figuring out complex hierarchies)
+
+### Parsing configs on the command line
+
+Because sometimes you might want to display the cumulative config files after the imports and interpolations have been resolved, we added as an alternative to dumping to a file a command-line based print of the collected config:
+
+```bash
+confuk parse <path-to-config>
+```

--- a/confuk/__init__.py
+++ b/confuk/__init__.py
@@ -1,3 +1,4 @@
 from .parse import parse_config
 from .dump import dump_config
 from .main_decorator import main
+from .doc import extract_docs, extract_docs_from_file

--- a/confuk/display.py
+++ b/confuk/display.py
@@ -1,0 +1,85 @@
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.tree import Tree
+from confuk.parse import flatten
+
+
+def display_flat(objs):
+    """Displays configs or documentation as a flat list using Markdown"""
+    console = Console()
+    output = "\n".join([f"**{key}**\n{desc}\n" for key, desc in objs.items()])
+    console.pager()  # Enable paging
+    console.print(Markdown(output))
+
+
+def display_tree(objs, tree_name: str = "*"):
+    """Displays configs or documentation as a tree structure"""
+    console = Console()
+    tree = Tree(f"[bold]{tree_name}[/bold]")
+    
+    nodes = {}
+    for key, doc in sorted(objs.items()):
+        parts = key.split('.')
+        current = tree
+        path = ""
+        for i, part in enumerate(parts):
+            path = f"{path}.{part}" if path else part
+            if path not in nodes:
+                new_node = current.add(f"[bold]{part}[/bold]" if i < len(parts) - 1 else f"[bold]{part}[/bold]: {doc}")
+                nodes[path] = new_node
+            current = nodes[path]
+    console.pager()
+    console.print(tree)
+
+
+def display_in_console(objs, tree_view=False, unpack: bool = False, md: bool = False):
+    """Renders configs/documentation to the console with optional tree view"""
+    if tree_view:
+        if unpack:
+            # `display_tree` accepts a flat list and then reconstructs
+            # a tree so we pass a flattened one here. It's a bit dumb
+            # and inefficient but I have no time to fix this now
+            objs_ = flatten(objs)
+        else:
+            objs_ = objs
+        display_tree(objs_)
+    else:
+        if md:
+            display_markdown_tree(objs)
+        else:
+            display_flat(objs)
+
+
+def display_markdown_tree(objs):
+    """Displays configs/documentation as an indented Markdown trees"""
+    def get_nested_dict():
+        from collections import defaultdict
+        return defaultdict(get_nested_dict)
+
+    def insert_nested(d, keys, value):
+        for key in keys[:-1]:
+            d = d[key]
+        d[keys[-1]] = value
+
+    # Build nested dict structure
+    nested = get_nested_dict()
+    for key, desc in objs.items():
+        parts = key.split('.')
+        insert_nested(nested, parts, desc)
+
+    # Recursively format Markdown
+    def format_markdown(d, level=0):
+        md = ""
+        indent = "    " * level
+        for k, v in d.items():
+            if isinstance(v, dict):
+                md += f"{indent}- **{k}**\n"
+                md += format_markdown(v, level + 1)
+            else:
+                md += f"{indent}- **{k}**: {v}\n"
+        return md
+
+    console = Console()
+    markdown_output = format_markdown(nested)
+    console.pager()
+    console.print(Markdown(markdown_output))

--- a/confuk/doc.py
+++ b/confuk/doc.py
@@ -1,0 +1,53 @@
+import webbrowser
+from omegaconf import OmegaConf, DictConfig as OmegaConfigDict
+from typing import *
+from pathlib import Path
+from confuk.parse import flatten, parse_config
+
+
+def extract_docs(config_dict: OmegaConfigDict):
+    """Extracts documentation comments from a config/docconfig object"""
+    return flatten(config_dict, "", ("_doc_",), use_parent_key_for_filter=True)
+
+
+def extract_docs_from_file(config_path: Path):
+    cfg = parse_config(config_path, "o")
+    return extract_docs(cfg)
+
+
+def generate_html(docs, output_file):
+    """Generates an HTML file with collapsible sections"""
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Configuration Documentation</title>
+        <style>
+            body { font-family: Arial, sans-serif; }
+            .section { margin-bottom: 10px; }
+            .header { font-weight: bold; cursor: pointer; color: blue; }
+            .content { display: none; padding-left: 10px; }
+        </style>
+        <script>
+            function toggleVisibility(id) {
+                var content = document.getElementById(id);
+                content.style.display = (content.style.display === 'block') ? 'none' : 'block';
+            }
+        </script>
+    </head>
+    <body>
+        <h1>Configuration Documentation</h1>
+    """
+    for i, (key, desc) in enumerate(docs.items()):
+        html_content += f'<div class="section">\n'
+        html_content += f'  <div class="header" onclick="toggleVisibility(\'section{i}\')">{key}</div>\n'
+        html_content += f'  <div id="section{i}" class="content">{desc}</div>\n'
+        html_content += f'</div>'
+    html_content += "</body></html>"
+    
+    Path(output_file).write_text(html_content)
+
+
+def open_in_browser(output_file):
+    """Opens the generated HTML file in the browser"""
+    webbrowser.open(f"file://{Path(output_file).resolve()}")

--- a/confuk/doc.py
+++ b/confuk/doc.py
@@ -15,13 +15,14 @@ def extract_docs_from_file(config_path: Path):
     return extract_docs(cfg)
 
 
-def generate_html(docs, output_file):
+def generate_html(docs, output_file, title="*"):
     """Generates an HTML file with collapsible sections"""
-    html_content = """
+    html_content = f"""
     <!DOCTYPE html>
     <html>
     <head>
-        <title>Configuration Documentation</title>
+        <title>{title}</title>
+    """ + """
         <style>
             body { font-family: Arial, sans-serif; }
             .section { margin-bottom: 10px; }
@@ -36,7 +37,8 @@ def generate_html(docs, output_file):
         </script>
     </head>
     <body>
-        <h1>Configuration Documentation</h1>
+    """ + f"""
+        <h1>{title}</h1>
     """
     for i, (key, desc) in enumerate(docs.items()):
         html_content += f'<div class="section">\n'

--- a/confuk/main.py
+++ b/confuk/main.py
@@ -1,0 +1,43 @@
+import click
+from rich.console import Console
+from confuk.parse import parse_config
+from confuk.display import display_in_console
+from confuk.doc import extract_docs_from_file, generate_html, open_in_browser
+from pathlib import Path
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command()
+@click.argument('config_file', type=click.Path(exists=True, path_type=Path))
+@click.option('-t', '--tree', is_flag=True, help="Print in a tree format")
+def parse(config_file: Path, tree: bool):
+    console = Console()
+    console.print(f"[blue]{config_file}[/blue]")
+    cfg = parse_config(config_file)
+    display_in_console(cfg, tree, unpack=True, md=True)
+
+
+@main.command()
+@click.argument('doc_file', type=click.Path(exists=True, path_type=Path))
+@click.option('-t', '--tree', is_flag=True, help="Print in a tree format")
+@click.option('-f', '--file', type=click.Path(path_type=Path),
+              default=None, help="If set, this should be a path to an output HTML file")
+@click.option('-o', '--open-html', is_flag=True,
+              help="Whether to open the HTML file in the web browser")
+def doc(doc_file: Path, tree: bool, file: Path | None, open_html: bool):
+    console = Console()
+    console.print(f"[blue]{doc_file}[/blue]")
+    docs = extract_docs_from_file(doc_file)
+    display_in_console(docs, tree, md=True)
+    if file is not None:
+        generate_html(docs, file)
+        if open_html:
+            open_in_browser(file)
+
+
+if __name__ == "__main__":
+    main()

--- a/confuk/main.py
+++ b/confuk/main.py
@@ -34,7 +34,7 @@ def doc(doc_file: Path, tree: bool, file: Path | None, open_html: bool):
     docs = extract_docs_from_file(doc_file)
     display_in_console(docs, tree, md=True)
     if file is not None:
-        generate_html(docs, file)
+        generate_html(docs, file, title=doc_file.stem)
         if open_html:
             open_in_browser(file)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,6 +36,20 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "click"
+version = "8.1.8"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -663,4 +677,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6ba5dc5d44ba6523fbb2ed11646053a699ac619e4ae8e5354d9dee9b2d8a128a"
+content-hash = "6519a97cf1875b91885d63bf9536d76667bb68e4dc676a5e2dc3e180c6d09d21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ omegaconf = "^2.3.0"
 ruamel-yaml = "^0.18.6"
 rich = "^13.8.1"
 jsonpickle = "^4.0.2"
+click = "^8.1.8"
 
 [tool.poetry.group.dev.dependencies]
 poethepoet = "^0.24.4"
@@ -24,3 +25,6 @@ pytest = "^8.3.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+confuk = "confuk.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "confuk"
-version = "0.8.1"
+version = "0.9.0"
 description = "Yet another configuration loading package for Python projects"
 authors = ["Krzysztof J. Czarnecki <kjczarne@gmail.com>"]
 license = "MIT"

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,0 +1,31 @@
+import unittest
+from confuk.parse import parse_config, flatten
+from confuk.doc import extract_docs
+from confuk.display import display_in_console
+from pathlib import Path
+
+
+class TestDocGeneration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg_path = Path(__file__).parent / "test_interpolation.toml"
+        cls.path = Path(__file__).parent / "test_doc.toml"
+
+    def test_flatten(self):
+        cfg = parse_config(self.cfg_path, "o")
+        flattened = flatten(cfg)
+        for k in ['something.subsomething.lol', 'something_else.value_str', 'something_else.path_to_this_file']:
+            self.assertIn(k, flattened.keys())
+        # print(flattened)
+
+    def test_doc_extraction(self):
+        cfg = parse_config(self.path, "o")
+        docs = extract_docs(cfg)
+        dct = {'': 'lol', 'something.subsomething': 'Now this is something!', 'something.subsomething_else': 'Now this is something else!'}
+        self.assertDictEqual(dct, docs)
+        # display_in_console(docs, tree_view=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_doc.toml
+++ b/test/test_doc.toml
@@ -1,0 +1,8 @@
+_doc_ = "lol"
+
+[something.subsomething]
+_doc_ = "Now this is something!"
+
+[something.subsomething_else]
+_doc_ = "Now this is something else!"
+


### PR DESCRIPTION
Resolves #2 

I had to go with a separate file for docs since there's no way to address parsing comments in YAML or TOML easily. And JSON formally does not support comment parsing at all.